### PR TITLE
Update installation with configuration

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,6 +51,10 @@ Als dit overschreden wordt, dan kan dit in het quota scherm aangepast worden:
 #### Authenticatie
 De authenticatie van KISS gebeurt m.b.v. Azure Active Directory.
 
+#### Configuratie
+
+
+
 ### Installatie
 Als het kubernetes cluster is ingericht, kunnen we de onderdelen van KISS gaan installeren.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -103,7 +103,7 @@ KISS gebruikt de SDG-api  om Kennisartikelen (PDC-producten) mee op te halen, en
 
 KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek op te halen en naar Elastic te pushen.
 
-**Let op**: alle API-keys die KISS nodig heeft om externe registers te bevragen moeten **minimaal 16 karakters** lang zijn
+**Let op**: Sommige  API-keys en Secretes die KISS nodig heeft om externe registers te bevragen moeten **minimaal 16 karakters** lang zijn. 
 
 
 | Variabele | Uitleg |  
@@ -119,10 +119,10 @@ KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek
 | enterprise_search_public_api | Nodig om de Elastic API te bevragen |
 | klanten_base_url | URL van de Klanten API voor het gebruikte klantenregister |
 | klanten_client_id | clientId voor het gebruikte klantenregister |
-| klanten_client_secret | secret voor het gebruikte klantenregister |
+| klanten_client_secret | secret voor het gebruikte klantenregister, deze moet **minimaal 16 karakters** lang zijn |
 | CONTACTMOMENTEN_BASE_URL  | RL van de Contactmomenten API voor het gebruikte Contactmomentenregister  |
 | CONTACTMOMENTEN_API_CLIENT_ID | clientId voor het gebruikte Contactmomentenregister |
-| CONTACTMOMENTEN_API_KEY  | API key te gebruiken door KISS voor het gebruikte Contactmomentenregister |
+| CONTACTMOMENTEN_API_KEY  | API key te gebruiken door KISS voor het gebruikte Contactmomentenregister, deze moet **minimaal 16 karakters** lang zijn. |
 | OBJECTEN_BASE_URL  | URL van de Objecten API  |
 | OBJECTEN_TOKEN  |  Token van de Objecten API |
 | OBJECTTYPES_BASE_URL  | URL van de Objecttype API  |
@@ -131,7 +131,7 @@ KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek
 | SDG_API_KEY  | URL van de API voor Kennisartikelen  |
 | ZAKEN_BASE_URL  |  URL waar de verschillende ZGW API's te benaderen zijn |
 | ZAKEN_API_CLIENT_ID  | clientId van de ZGW API's |
-| ZAKEN_API_KEY  | API Key van de ZGW API's  |
+| ZAKEN_API_KEY  | API Key van de ZGW API's, deze moet **minimaal 16 karakters** lang zijn |
 
 
 ### Installatie

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,7 +51,82 @@ Als dit overschreden wordt, dan kan dit in het quota scherm aangepast worden:
 #### Authenticatie
 De authenticatie van KISS gebeurt m.b.v. Azure Active Directory.
 
-#### Configuratie
+### Configuratie: variabelen
+Voor elke installatie zijn een aantal environment variabelen nodig. Per ondderdeel van KISS geven we aan welke variabelen gevuld moeten worden.  
+
+#### Authenticatie
+Voor Authenticatie maakt KISS gebruik van een OpenIDConnect Identity Provider. 
+
+| Variabele  | Uitleg  |  In installatiescript  |
+|---|---|---|
+| oidcClientId  |   |  |
+| oidcClientSecret  |   |  |
+
+#### Database
+Er zijn verschillende gegevens die binnen KISS zelf worden opgeslagen, zoals Nieuws en Werkinstructies, Links, en managementinformatie. 
+
+| Variabele  | Uitleg  |  In installatiescript  |
+|---|---|---|
+| postgresDb  |   |  |
+| postgresPassword  |   |  |
+| postgresUser  |   |  |
+
+
+#### Organisatie RSIN
+Bij het opslaan van contactmomenten moet het RSIN van de organisatie worden meegestuurd. Deze stelt u in bij ORGANISATIE_IDS
+
+| Variabele  | Uitleg  |  In installatiescript  |
+|---|---|---|
+| ORGANISATIE_IDS  |   |  |
+
+#### Feedback op Kennisartikelen
+Vanuit KISS kan een KCM feedback geven op een kennisartikel. Deze informatie wordt gemaild naar één centraal mailadres
+
+| Variabele  | Uitleg  |  In installatiescript  |
+|---|---|---|
+| EMAIL_ENABLE_SSL  | Gaat de mail via SSL true/false  |  |
+| EMAIL_HOST  |   |  |
+| EMAIL_PASSWORD  |   |  |
+| EMAIL_PORT  |   |  |
+| EMAIL_USERNAME  |   |  |
+| FEEDBACK_EMAIL_FROM  |   |  |
+| FEEDBACK_EMAIL_TO  |   |  |
+
+
+| imageTag  | Dit is de verwijzing naar de versie Build van KISS-frontend respository  |  |
+
+
+
+| elasticPassword  |   |  |
+| enterprise_search_private_api  |   |  |
+| enterprise_search_public_api  |   |  |
+| enterprise_search_url  |   |  |
+| haalCentraalApiKey  |   |  |
+| haalCentraalBaseUrl |   |  |
+| kvkApiKey  |   |  |
+| kvkBaseUrl  |   |  |
+
+| klanten_base_url |   |  |
+| klanten_client_id  |   |  |
+| klanten_client_secret  |   |  |
+| CONTACTMOMENTEN_API_CLIENT_ID  |   |  |
+| CONTACTMOMENTEN_API_KEY  |   |  |
+| CONTACTMOMENTEN_BASE_URL  |   |  |
+
+
+| OBJECTEN_BASE_URL  |   |  |
+| OBJECTEN_TOKEN  |   |  |
+| OBJECTTYPES_BASE_URL  |   |  |
+| OBJECTTYPES_TOKEN  |   |  |
+| SDG_API_KEY  |   |  |
+| SDG_BASE_URL  |   |  |
+| ZAKEN_API_CLIENT_ID  |   |  |
+| ZAKEN_API_KEY  |   |  |
+| ZAKEN_BASE_URL  |   |  |
+
+
+
+
 
 
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -52,14 +52,14 @@ Als dit overschreden wordt, dan kan dit in het quota scherm aangepast worden:
 De authenticatie van KISS gebeurt m.b.v. Azure Active Directory.
 
 ### Configuratie: environment variabelen
-Voor elke installatie zijn een aantal environment variabelen nodig. Per ondderdeel van KISS geven we aan welke variabelen gevuld moeten worden. In de hieronder genoemde innstallatiescripts, en in values.yaml zijn in sommige gevallen al default waarden ingevuld.
+Voor elke installatie zijn een aantal environment variabelen nodig. Per onderdeel van KISS geven we aan welke variabelen gevuld moeten worden. In de hieronder genoemde innstallatiescripts, en in values.yaml zijn in sommige gevallen al default waarden ingevuld.
 
 #### Authenticatie
 Voor Authenticatie maakt KISS gebruik van een OpenIDConnect Identity Provider. 
 
 | Variabele | Uitleg |  
 |---|---|
-| oidcAuthority | URL van de OpenID Connect Identity Provider
+| oidcAuthority | URL van de OpenID Connect Identity Provider |
 | oidcClientId | Voor toegang tot de OpenID Connect Identity Provider |
 | oidcClientSecret | OpenID Connect Identity Provider | 
 
@@ -77,14 +77,14 @@ Er zijn verschillende gegevens die binnen KISS zelf worden opgeslagen, zoals Nie
 Verschillende ZGW APIs, waaronder de Klant en Contactmoment APIs, vragen om een identificatienummer van de organisatie.
 
 | Variabele | Uitleg |  
-|---|---|---|
+|---|---|
 | ORGANISATIE_IDS | RSIN van de organisatie die de Contactmomenten registreert |
 
 #### Feedback op Kennisartikelen
 Vanuit KISS kan een KCM feedback geven op een kennisartikel. Deze informatie wordt gemaild naar één centraal mailadres
 
 | Variabele | Uitleg |
-|---|---|---|
+|---|---|
 | FEEDBACK_EMAIL_FROM | Het afzenderadres van de mail met feedback erin | 
 | FEEDBACK_EMAIL_TO | Het adres waar de mail met feedback naar toe moet | 
 | EMAIL_ENABLE_SSL | Gaat de mail via SSL true/false |
@@ -107,8 +107,8 @@ KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek
 
 
 | Variabele | Uitleg |  
-|---|---|-
-| imageTag | Dit is de verwijzing naar de versie Build van KISS-frontend respository  
+|---|---|
+| imageTag | Dit is de verwijzing naar de versie Build van KISS-frontend respository |
 | haalCentraalBaseUrl | URL van de Haal Centraal API om de BRP te bevragen |
 | haalCentraalApiKey | Key om de Haal Centraal API te bevragen |
 | kvkBaseUrl | URL van de KvK-API om het Handelsregister te bevragen | 
@@ -132,8 +132,6 @@ KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek
 | ZAKEN_BASE_URL  |  URL waar de verschillende ZGW API's te benaderen zijn |
 | ZAKEN_API_CLIENT_ID  | clientId van de ZGW API's |
 | ZAKEN_API_KEY  | API Key van de ZGW API's  |
-
-
 
 
 ### Installatie

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,81 +51,87 @@ Als dit overschreden wordt, dan kan dit in het quota scherm aangepast worden:
 #### Authenticatie
 De authenticatie van KISS gebeurt m.b.v. Azure Active Directory.
 
-### Configuratie: variabelen
-Voor elke installatie zijn een aantal environment variabelen nodig. Per ondderdeel van KISS geven we aan welke variabelen gevuld moeten worden.  
+### Configuratie: environment variabelen
+Voor elke installatie zijn een aantal environment variabelen nodig. Per ondderdeel van KISS geven we aan welke variabelen gevuld moeten worden. In de hieronder genoemde innstallatiescripts, en in values.yaml zijn in sommige gevallen al default waarden ingevuld.
 
 #### Authenticatie
 Voor Authenticatie maakt KISS gebruik van een OpenIDConnect Identity Provider. 
 
-| Variabele  | Uitleg  |  In installatiescript  |
-|---|---|---|
-| oidcClientId  |   |  |
-| oidcClientSecret  |   |  |
+| Variabele | Uitleg |  
+|---|---|
+| oidcAuthority | URL van de OpenID Connect Identity Provider
+| oidcClientId | Voor toegang tot de OpenID Connect Identity Provider |
+| oidcClientSecret | OpenID Connect Identity Provider | 
 
 #### Database
 Er zijn verschillende gegevens die binnen KISS zelf worden opgeslagen, zoals Nieuws en Werkinstructies, Links, en managementinformatie. 
 
-| Variabele  | Uitleg  |  In installatiescript  |
-|---|---|---|
-| postgresDb  |   |  |
-| postgresPassword  |   |  |
-| postgresUser  |   |  |
+| Variabele | Uitleg | 
+|---|---|
+| postgresDb | Naam van de database bij KISS |
+| postgresUser | Gebruikersnaam waarmee KISS toegang krijgt tot de DB |
+| postgresPassword | Wachtwoord van de postgresUser |
 
 
 #### Organisatie RSIN
-Bij het opslaan van contactmomenten moet het RSIN van de organisatie worden meegestuurd. Deze stelt u in bij ORGANISATIE_IDS
+Verschillende ZGW APIs, waaronder de Klant en Contactmoment APIs, vragen om een identificatienummer van de organisatie.
 
-| Variabele  | Uitleg  |  In installatiescript  |
+| Variabele | Uitleg |  
 |---|---|---|
-| ORGANISATIE_IDS  |   |  |
+| ORGANISATIE_IDS | RSIN van de organisatie die de Contactmomenten registreert |
 
 #### Feedback op Kennisartikelen
 Vanuit KISS kan een KCM feedback geven op een kennisartikel. Deze informatie wordt gemaild naar één centraal mailadres
 
-| Variabele  | Uitleg  |  In installatiescript  |
+| Variabele | Uitleg |
 |---|---|---|
-| EMAIL_ENABLE_SSL  | Gaat de mail via SSL true/false  |  |
-| EMAIL_HOST  |   |  |
-| EMAIL_PASSWORD  |   |  |
-| EMAIL_PORT  |   |  |
-| EMAIL_USERNAME  |   |  |
-| FEEDBACK_EMAIL_FROM  |   |  |
-| FEEDBACK_EMAIL_TO  |   |  |
+| FEEDBACK_EMAIL_FROM | Het afzenderadres van de mail met feedback erin | 
+| FEEDBACK_EMAIL_TO | Het adres waar de mail met feedback naar toe moet | 
+| EMAIL_ENABLE_SSL | Gaat de mail via SSL true/false |
+| EMAIL_HOST | Adres van de mailserver die de mail moet versturen | 
+| EMAIL_PORT | poortnummer van de mailverbinding | 
+| EMAIL_USERNAME | Username van het account dat zich aanmeldt bij de mailserver | 
+| EMAIL_PASSWORD | Wachtwoord bij de username | 
 
 
-| imageTag  | Dit is de verwijzing naar de versie Build van KISS-frontend respository  |  |
+#### Gekoppelde bronnen
+Er zijn diverse bronnen die vanuit KISS via API's bevraagd worden. Sommige worden alleen geraadpleegd, zoals de KvK-API en de API voor Haal Centraal BRP Personen bevragen. 
+
+Andere registraties worden niet alleen geraadpleegd, maar er worden ook gegevens in weggeschreven. Dit zijn in ieder geval een Zaaksysteem (m.b.v. ZGW API's) zoals Open Zaak, en een Klanten- en Contactmomentenregister, zoals Open Klant. 
+
+KISS gebruikt de SDG-api  om Kennisartikelen (PDC-producten) mee op te halen, en naar Elastic te pushen. 
+
+KISS gebruikt op dit moment de Objecten API om de Medewerkers in het Smoelenboek op te halen en naar Elastic te pushen.
+
+**Let op**: alle API-keys die KISS nodig heeft om externe registers te bevragen moeten **minimaal 16 karakters** lang zijn
 
 
-
-| elasticPassword  |   |  |
-| enterprise_search_private_api  |   |  |
-| enterprise_search_public_api  |   |  |
-| enterprise_search_url  |   |  |
-| haalCentraalApiKey  |   |  |
-| haalCentraalBaseUrl |   |  |
-| kvkApiKey  |   |  |
-| kvkBaseUrl  |   |  |
-
-| klanten_base_url |   |  |
-| klanten_client_id  |   |  |
-| klanten_client_secret  |   |  |
-| CONTACTMOMENTEN_API_CLIENT_ID  |   |  |
-| CONTACTMOMENTEN_API_KEY  |   |  |
-| CONTACTMOMENTEN_BASE_URL  |   |  |
-
-
-| OBJECTEN_BASE_URL  |   |  |
-| OBJECTEN_TOKEN  |   |  |
-| OBJECTTYPES_BASE_URL  |   |  |
-| OBJECTTYPES_TOKEN  |   |  |
-| SDG_API_KEY  |   |  |
-| SDG_BASE_URL  |   |  |
-| ZAKEN_API_CLIENT_ID  |   |  |
-| ZAKEN_API_KEY  |   |  |
-| ZAKEN_BASE_URL  |   |  |
-
-
-
+| Variabele | Uitleg |  
+|---|---|-
+| imageTag | Dit is de verwijzing naar de versie Build van KISS-frontend respository  
+| haalCentraalBaseUrl | URL van de Haal Centraal API om de BRP te bevragen |
+| haalCentraalApiKey | Key om de Haal Centraal API te bevragen |
+| kvkBaseUrl | URL van de KvK-API om het Handelsregister te bevragen | 
+| kvkApiKey | Key om de Kvk-API te bevragen |
+| enterprise_search_url | URL van de API waarop KISS de elastic instantie kan bevragen | 
+| elasticPassword | Nodig om de Elastic API te bevragen |
+| enterprise_search_private_api | Nodig om de Elastic API te bevragen |
+| enterprise_search_public_api | Nodig om de Elastic API te bevragen |
+| klanten_base_url | URL van de Klanten API voor het gebruikte klantenregister |
+| klanten_client_id | clientId voor het gebruikte klantenregister |
+| klanten_client_secret | secret voor het gebruikte klantenregister |
+| CONTACTMOMENTEN_BASE_URL  | RL van de Contactmomenten API voor het gebruikte Contactmomentenregister  |
+| CONTACTMOMENTEN_API_CLIENT_ID | clientId voor het gebruikte Contactmomentenregister |
+| CONTACTMOMENTEN_API_KEY  | API key te gebruiken door KISS voor het gebruikte Contactmomentenregister |
+| OBJECTEN_BASE_URL  | URL van de Objecten API  |
+| OBJECTEN_TOKEN  |  Token van de Objecten API |
+| OBJECTTYPES_BASE_URL  | URL van de Objecttype API  |
+| OBJECTTYPES_TOKEN  | Token van de Objecttype API  |
+| SDG_BASE_URL  | URL van de API waarmee Kennisartikelen (PDC-producten) kunnen worden opgehaald door KISS |
+| SDG_API_KEY  | URL van de API voor Kennisartikelen  |
+| ZAKEN_BASE_URL  |  URL waar de verschillende ZGW API's te benaderen zijn |
+| ZAKEN_API_CLIENT_ID  | clientId van de ZGW API's |
+| ZAKEN_API_KEY  | API Key van de ZGW API's  |
 
 
 

--- a/docs/scripts/1_install_kiss.ps1
+++ b/docs/scripts/1_install_kiss.ps1
@@ -23,13 +23,44 @@ helm upgrade --install eck-operator elastic-repo/eck-operator --version 2.5.0
 
 helm upgrade --install kiss-ci-release kiss-repo-ci/kiss-frontend --version 1.0.35 `
 --values [local dir]\kiss.template.yaml `
---set elasticstack.credentials.password=[password], `
-env.HAAL_CENTRAAL_API_KEY=[apikey], `
-env.POSTGRES_PASSWORD=[db_pass], `
-env.OIDC_CLIENT_ID=f73cab23-1291-40c3-b2ba-263634ddd262, `
-env.OIDC_AUTHORITY=https://login.microsoftonline.com/0571c846-217a-43f0-baa6-a9f8a19865a8/v2.0, `
-env.KVK_BASE_URL=https://api.kvk.nl/test/api/v1, `
-env.KVK_API_KEY=l7xx1f2691f2520d487b902f4e0b57a0b197, `
-env.HAAL_CENTRAAL_BASE_URL=https://proefomgeving.haalcentraal.nl/haalcentraal/api, `
-env.POSTGRES_USER=kiss.bff, `
-env.POSTGRES_DB=kiss.bff
+--set image.tag=$(imageTag), `
+elasticstack.credentials.password=$(elasticPassword), `
+env.OIDC_CLIENT_SECRET=$(oidcClientSecret), `
+env.OIDC_CLIENT_ID=$(oidcClientId), `
+env.OIDC_AUTHORITY=$(oidcAuthority), `
+env.KVK_BASE_URL=$(kvkBaseUrl), `
+env.KVK_API_KEY=$(kvkApiKey), `
+env.HAAL_CENTRAAL_API_KEY=$(haalCentraalApiKey), `
+env.HAAL_CENTRAAL_BASE_URL=$(haalCentraalBaseUrl), `
+env.POSTGRES_PASSWORD=$(postgresPassword), `
+env.POSTGRES_USER=$(postgresUser), `
+env.POSTGRES_DB=$(postgresDb), `
+env.ENTERPRISE_SEARCH_BASE_URL=$(enterprise_search_url), `
+env.ENTERPRISE_SEARCH_PRIVATE_API_KEY=$(enterprise_search_private_api), `
+env.ENTERPRISE_SEARCH_PUBLIC_API_KEY=$(enterprise_search_public_api), `
+env.ZAKEN_BASE_URL=$(ZAKEN_BASE_URL), `
+env.ZAKEN_API_KEY=$(ZAKEN_API_KEY), `
+env.ZAKEN_API_CLIENT_ID=$(ZAKEN_API_CLIENT_ID), `
+env.KLANTEN_BASE_URL=$(klanten_base_url), `
+env.KLANTEN_CLIENT_ID=$(klanten_client_id), `
+env.KLANTEN_CLIENT_SECRET=$(klanten_client_secret), `
+env.EMAIL_HOST=$(EMAIL_HOST), `
+env.EMAIL_PORT=$(EMAIL_PORT), `
+env.EMAIL_USERNAME=$(EMAIL_USERNAME), `
+env.EMAIL_PASSWORD=$(EMAIL_PASSWORD), `
+env.EMAIL_ENABLE_SSL=$(EMAIL_ENABLE_SSL), `
+env.FEEDBACK_EMAIL_FROM=$(FEEDBACK_EMAIL_FROM), `
+env.FEEDBACK_EMAIL_TO=$(FEEDBACK_EMAIL_TO), `
+env.CONTACTMOMENTEN_BASE_URL=$(CONTACTMOMENTEN_BASE_URL), `
+env.CONTACTMOMENTEN_API_KEY=$(CONTACTMOMENTEN_API_KEY), `
+env.CONTACTMOMENTEN_API_CLIENT_ID=$(CONTACTMOMENTEN_API_CLIENT_ID), `
+env.OBJECTEN_BASE_URL=$(OBJECTEN_BASE_URL), `
+env.OBJECTEN_TOKEN=$(OBJECTEN_TOKEN), `
+env.OBJECTTYPES_BASE_URL=$(OBJECTTYPES_BASE_URL), `
+env.OBJECTTYPES_TOKEN=$(OBJECTTYPES_TOKEN), `
+env.SDG_BASE_URL=$(SDG_BASE_URL), `
+env.SDG_API_KEY=$(SDG_API_KEY), `
+global.postgresql.auth.username=$(postgresUser), `
+global.postgresql.auth.password=$(postgresPassword), `
+global.postgresql.auth.database=$(postgresDb), `
+global.postgresql.auth.postgresPassword=$(postgresPassword)env.ORGANISATIE_IDS=$(ORGANISATIE_IDS)


### PR DESCRIPTION
In de Installatiehandleiding heb ik een hoofdstuk opgenomen, Configuratie: environment variabelen. Hierin heb ik de verschillende environmentvariabelen inhoudelijk gegroepeerd, en per variabele een kort uitleg gegeven. 

Belangrijke vraag: welke API-keys moeten allemaal minimaal 16 tekens lang zijn? 
Ik heb dit iig opgenomen bij Gekoppelde bronnen. Klopt dat, of moet dit op meer plekken genoteerd worden? 